### PR TITLE
Shorten `reference_pkg` argument name to `ref`

### DIFF
--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -29,13 +29,13 @@
 #'   dependencies of a specific package.
 #'
 #' - `get_min_version_required()` will return, if any, the minimum version
-#'   of `pkg` required by `reference_pkg`.
+#'   of `pkg` required by `ref`.
 #'
 #' @param pkg (`character`)\cr
 #'   vector of package names to check.
 #' @param call (`environment`)\cr
 #'   frame for error messaging. Default is [get_cli_abort_call()].
-#' @param reference_pkg (`string`)\cr
+#' @param ref (`string`)\cr
 #'   name of the package the function will search for a minimum required version from.
 #' @param lib.loc (`path`)\cr
 #'   location of `R` library trees to search through, see [utils::packageDescription()].
@@ -61,16 +61,16 @@ NULL
 #' @keywords internal
 #' @noRd
 check_pkg_installed <- function(pkg,
-                                reference_pkg = "cards",
+                                ref = "cards",
                                 call = get_cli_abort_call()) {
   # check inputs ---------------------------------------------------------------
   check_not_missing(pkg)
   check_class(pkg, cls = "character")
-  check_string(reference_pkg, allow_empty = TRUE)
+  check_string(ref, allow_empty = TRUE)
 
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
-    get_min_version_required(pkg = pkg, reference_pkg = reference_pkg, call = call)
+    get_min_version_required(pkg = pkg, ref = ref, call = call)
 
   # prompt user to install package ---------------------------------------------
   rlang::check_installed(
@@ -87,16 +87,16 @@ check_pkg_installed <- function(pkg,
 #' @keywords internal
 #' @noRd
 is_pkg_installed <- function(pkg,
-                             reference_pkg = "cards",
+                             ref = "cards",
                              call = get_cli_abort_call()) {
   # check inputs ---------------------------------------------------------------
   check_not_missing(pkg)
   check_class(pkg, cls = "character")
-  check_string(reference_pkg, allow_empty = TRUE)
+  check_string(ref, allow_empty = TRUE)
 
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
-    get_min_version_required(pkg = pkg, reference_pkg = reference_pkg, call = call)
+    get_min_version_required(pkg = pkg, ref = ref, call = call)
 
   # check installation TRUE/FALSE ----------------------------------------------
   rlang::is_installed(
@@ -111,14 +111,14 @@ is_pkg_installed <- function(pkg,
 #' @inheritParams check_pkg_installed
 #' @keywords internal
 #' @noRd
-get_pkg_dependencies <- function(reference_pkg = "cards", lib.loc = NULL, call = get_cli_abort_call()) {
-  check_string(reference_pkg, allow_empty = TRUE, call = call)
+get_pkg_dependencies <- function(ref = "cards", lib.loc = NULL, call = get_cli_abort_call()) {
+  check_string(ref, allow_empty = TRUE, call = call)
 
-  if (rlang::is_empty(reference_pkg)) {
+  if (rlang::is_empty(ref)) {
     return(.empty_pkg_deps_df())
   }
 
-  description <- utils::packageDescription(reference_pkg, lib.loc = lib.loc) |> suppressWarnings()
+  description <- utils::packageDescription(ref, lib.loc = lib.loc) |> suppressWarnings()
   if (identical(description, NA)) {
     return(.empty_pkg_deps_df())
   }
@@ -170,14 +170,14 @@ get_pkg_dependencies <- function(reference_pkg = "cards", lib.loc = NULL, call =
 #' @inheritParams check_pkg_installed
 #' @keywords internal
 #' @noRd
-get_min_version_required <- function(pkg, reference_pkg = "cards",
+get_min_version_required <- function(pkg, ref = "cards",
                                      lib.loc = NULL, call = get_cli_abort_call()) {
   check_not_missing(pkg, call = call)
   check_class(pkg, cls = "character", call = call)
-  check_string(reference_pkg, allow_empty = TRUE, call = call)
+  check_string(ref, allow_empty = TRUE, call = call)
 
   # if no package reference, return a df with just the pkg names
-  if (rlang::is_empty(reference_pkg)) {
+  if (rlang::is_empty(ref)) {
     return(
       .empty_pkg_deps_df() |>
         dplyr::full_join(
@@ -190,7 +190,7 @@ get_min_version_required <- function(pkg, reference_pkg = "cards",
   # get the package_ref deps and subset on requested pkgs, also supplement df with pkgs
   # that may not be proper deps of the reference package (these pkgs don't have min versions)
   res <-
-    get_pkg_dependencies(reference_pkg, lib.loc = lib.loc) |>
+    get_pkg_dependencies(ref, lib.loc = lib.loc) |>
     dplyr::filter(.data$pkg %in% .env$pkg) |>
     dplyr::full_join(
       dplyr::tibble(pkg = pkg),

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -29,7 +29,6 @@
 #'   dependencies of a specific package.
 #'
 #' - `get_min_version_required()` will return, if any, the minimum version of `pkg` required by `ref`.
-#'   of `pkg` required by `ref`.
 #'
 #' @param pkg (`character`)\cr
 #'   vector of package names to check.
@@ -37,7 +36,6 @@
 #'   frame for error messaging. Default is [get_cli_abort_call()].
 #' @param ref (`string`)\cr
 #'   name of the package the function will search for a minimum required version from.
-#'   in which the current environment or function exists will be used.
 #' @param lib.loc (`path`)\cr
 #'   location of `R` library trees to search through, see [utils::packageDescription()].
 #'
@@ -74,6 +72,8 @@ NULL
 check_pkg_installed <- function(pkg,
                                 ref = packageName(),
                                 call = get_cli_abort_call()) {
+  if (!is.character(ref) && !is.null(ref)) cli::cli_abort("{.arg ref} must be a string.")
+
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, ref = ref)
@@ -94,6 +94,8 @@ check_pkg_installed <- function(pkg,
 #' @noRd
 is_pkg_installed <- function(pkg,
                              ref = packageName()) {
+  if (!is.character(ref) && !is.null(ref)) cli::cli_abort("{.arg ref} must be a string.")
+
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, ref = ref)
@@ -116,6 +118,8 @@ is_pkg_installed <- function(pkg,
 #'
 #' @noRd
 get_pkg_dependencies <- function(pkg = packageName(), lib.loc = NULL) {
+  if (!is.character(pkg) && !is.null(pkg)) cli::cli_abort("{.arg pkg} must be a string.")
+
   if (rlang::is_empty(pkg)) {
     return(.empty_pkg_deps_df())
   }
@@ -173,6 +177,8 @@ get_pkg_dependencies <- function(pkg = packageName(), lib.loc = NULL) {
 #' @keywords internal
 #' @noRd
 get_min_version_required <- function(pkg, ref = packageName(), lib.loc = NULL) {
+  if (!is.character(ref) && !is.null(ref)) cli::cli_abort("{.arg ref} must be a string.")
+
   # if no package reference, return a df with just the pkg names
   if (rlang::is_empty(ref)) {
     return(

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -100,12 +100,12 @@ is_pkg_installed <- function(pkg,
 #' @inheritParams check_pkg_installed
 #' @keywords internal
 #' @noRd
-get_pkg_dependencies <- function(ref = "cards", lib.loc = NULL) {
-  if (rlang::is_empty(ref)) {
+get_pkg_dependencies <- function(pkg = "cards", lib.loc = NULL) {
+  if (rlang::is_empty(pkg)) {
     return(.empty_pkg_deps_df())
   }
 
-  description <- utils::packageDescription(ref, lib.loc = lib.loc) |> suppressWarnings()
+  description <- utils::packageDescription(pkg, lib.loc = lib.loc) |> suppressWarnings()
   if (identical(description, NA)) {
     return(.empty_pkg_deps_df())
   }

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -28,7 +28,7 @@
 #' - `get_pkg_dependencies()` returns a tibble with all
 #'   dependencies of a specific package.
 #'
-#' - `get_min_version_required()` will return, if any, the minimum version
+#' - `get_min_version_required()` will return, if any, the minimum version of `pkg` required by `ref`.
 #'   of `pkg` required by `ref`.
 #'
 #' @param pkg (`character`)\cr
@@ -36,10 +36,20 @@
 #' @param call (`environment`)\cr
 #'   frame for error messaging. Default is [get_cli_abort_call()].
 #' @param ref (`string`)\cr
-#'   name of the package the function will search for a minimum required version from. If `packageName()`, the package
+#'   name of the package the function will search for a minimum required version from.
 #'   in which the current environment or function exists will be used.
 #' @param lib.loc (`path`)\cr
 #'   location of `R` library trees to search through, see [utils::packageDescription()].
+#'
+#' @details
+#' The `ref` argument (`pkg` in `get_pkg_dependencies`) uses `packageName()` as a default, which returns the package in
+#' which the current environment or function is run from. The current environment is determined via `parent.frame()`.
+#'
+#' If, for example, `get_min_version_required("dplyr", ref = packageName())` is run within a `cards` function, and this
+#' function is then called within a function of the `cardx` package, the minimum version returned by the
+#' `get_min_version_required` call will return the version required by the `cards` package. If run within a test file,
+#' `packageName()` returns the package of the current test. Within Roxygen `@examplesIf` calls, `packageName()` will
+#' returns the package of the current example.
 #'
 #' @return `is_pkg_installed()` and `check_pkg_installed()` returns a logical or error,
 #' `get_min_version_required()` returns a data frame with the minimum version required,
@@ -102,8 +112,7 @@ is_pkg_installed <- function(pkg,
 #' @keywords internal
 #'
 #' @param pkg (`string`)\cr
-#'   name of the package the function will search for a minimum required version from. If `packageName()`, the package
-#'   in which the current environment or function exists will be used.
+#'   name of the package the function will search for dependencies from.
 #'
 #' @noRd
 get_pkg_dependencies <- function(pkg = packageName(), lib.loc = NULL) {

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -36,7 +36,8 @@
 #' @param call (`environment`)\cr
 #'   frame for error messaging. Default is [get_cli_abort_call()].
 #' @param ref (`string`)\cr
-#'   name of the package the function will search for a minimum required version from.
+#'   name of the package the function will search for a minimum required version from. If `packageName()`, the package
+#'   in which the current environment or function exists will be used.
 #' @param lib.loc (`path`)\cr
 #'   location of `R` library trees to search through, see [utils::packageDescription()].
 #'
@@ -99,6 +100,11 @@ is_pkg_installed <- function(pkg,
 
 #' @inheritParams check_pkg_installed
 #' @keywords internal
+#'
+#' @param pkg (`string`)\cr
+#'   name of the package the function will search for a minimum required version from. If `packageName()`, the package
+#'   in which the current environment or function exists will be used.
+#'
 #' @noRd
 get_pkg_dependencies <- function(pkg = packageName(), lib.loc = NULL) {
   if (rlang::is_empty(pkg)) {

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -61,7 +61,7 @@ NULL
 #' @keywords internal
 #' @noRd
 check_pkg_installed <- function(pkg,
-                                ref = "cards",
+                                ref = packageName(),
                                 call = get_cli_abort_call()) {
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
@@ -82,7 +82,7 @@ check_pkg_installed <- function(pkg,
 #' @keywords internal
 #' @noRd
 is_pkg_installed <- function(pkg,
-                             ref = "cards") {
+                             ref = packageName()) {
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, ref = ref)
@@ -100,7 +100,7 @@ is_pkg_installed <- function(pkg,
 #' @inheritParams check_pkg_installed
 #' @keywords internal
 #' @noRd
-get_pkg_dependencies <- function(pkg = "cards", lib.loc = NULL) {
+get_pkg_dependencies <- function(pkg = packageName(), lib.loc = NULL) {
   if (rlang::is_empty(pkg)) {
     return(.empty_pkg_deps_df())
   }
@@ -157,7 +157,7 @@ get_pkg_dependencies <- function(pkg = "cards", lib.loc = NULL) {
 #' @inheritParams check_pkg_installed
 #' @keywords internal
 #' @noRd
-get_min_version_required <- function(pkg, ref = "cards", lib.loc = NULL) {
+get_min_version_required <- function(pkg, ref = packageName(), lib.loc = NULL) {
   # if no package reference, return a df with just the pkg names
   if (rlang::is_empty(ref)) {
     return(

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -61,7 +61,8 @@ NULL
 #' @keywords internal
 #' @noRd
 check_pkg_installed <- function(pkg,
-                                ref = "cards") {
+                                ref = "cards",
+                                call = get_cli_abort_call()) {
   # get min version data -------------------------------------------------------
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, ref = ref)

--- a/R/standalone-stringr.R
+++ b/R/standalone-stringr.R
@@ -25,8 +25,8 @@ str_squish <- function(string, fixed = FALSE, perl = !fixed) {
   return(string)
 }
 
-str_remove <- function (string, pattern, fixed = FALSE, perl = !fixed) {
-  sub (x = string, pattern = pattern, replacement = "", fixed = fixed, perl = perl)
+str_remove <- function(string, pattern, fixed = FALSE, perl = !fixed) {
+  sub(x = string, pattern = pattern, replacement = "", fixed = fixed, perl = perl)
 }
 
 str_remove_all <- function(string, pattern, fixed = FALSE, perl = !fixed) {
@@ -53,7 +53,7 @@ str_replace <- function(string, pattern, replacement, fixed = FALSE, perl = !fix
   sub(x = string, pattern = pattern, replacement = replacement, fixed = fixed, perl = perl)
 }
 
-str_replace_all <- function (string, pattern, replacement, fixed = FALSE, perl = !fixed){
+str_replace_all <- function(string, pattern, replacement, fixed = FALSE, perl = !fixed) {
   gsub(x = string, pattern = pattern, replacement = replacement, fixed = fixed, perl = perl)
 }
 
@@ -84,7 +84,7 @@ word <- function(string, start, end = start, sep = " ", fixed = TRUE, perl = !fi
   }
 }
 
-str_sub <- function(string, start = 1L, end = -1L){
+str_sub <- function(string, start = 1L, end = -1L) {
   str_length <- nchar(string)
 
   # Adjust start and end indices for negative values
@@ -98,11 +98,11 @@ str_sub <- function(string, start = 1L, end = -1L){
   substr(x = string, start = start, stop = end)
 }
 
-str_sub_all <- function(string, start = 1L, end = -1L){
+str_sub_all <- function(string, start = 1L, end = -1L) {
   lapply(string, function(x) substr(x, start = start, stop = end))
 }
 
-str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ", use_width = TRUE){
+str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ", use_width = TRUE) {
   side <- match.arg(side, c("left", "right", "both"))
 
   if (side == "both") {
@@ -127,7 +127,7 @@ str_split <- function(string, pattern, n = Inf, fixed = FALSE, perl = !fixed) {
     parts <- strsplit(string, split = pattern, fixed = fixed, perl = perl)
     lapply(parts, function(x) {
       if (length(x) > n) {
-        x <- c(x[1:(n-1)], paste(x[n:length(x)], collapse = pattern))
+        x <- c(x[1:(n - 1)], paste(x[n:length(x)], collapse = pattern))
       }
       return(x)
     })

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -22,7 +22,7 @@ test_that("check_pkg_installed() works", {
     )
   )
   expect_equal(
-    get_min_version_required("brms", reference_pkg = NULL),
+    get_min_version_required("brms", ref = NULL),
     dplyr::tibble(
       reference_pkg = NA_character_, reference_pkg_version = NA_character_,
       dependency_type = NA_character_, pkg = "brms", version = NA_character_,
@@ -30,7 +30,7 @@ test_that("check_pkg_installed() works", {
     )
   )
   expect_equal(
-    get_min_version_required("dplyr", reference_pkg = NULL),
+    get_min_version_required("dplyr", ref = NULL),
     dplyr::tibble(
       reference_pkg = NA_character_, reference_pkg_version = NA_character_,
       dependency_type = NA_character_, pkg = "dplyr", version = NA_character_,


### PR DESCRIPTION
Closes #26 

I applied this change to all functions including `get_pkg_dependencies()` and `get_min_version_required()` - is this correct? Only the `*_pkg_installed()` functions were specified in the issue.